### PR TITLE
Check for s. overflow before it happens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 CFLAGS:=-Wall -Wextra -g
-CC:=cc
 EXTENSION:=
 
 TEST_FLAGS:=

--- a/safe.h
+++ b/safe.h
@@ -391,9 +391,11 @@ SAFE_DEFINE_LARGER_OPS(uint64_t, uint64)
 #define SAFE_DEFINE_SIGNED_ADD(T, name, min, max) \
   SAFE_STATIC_INLINE _Bool \
   safe_##name##_add (T* res, T a, T b) { \
-    *res = (T) (a + b); \
-    return !SAFE_UNLIKELY(((b > 0) && (a > (max - b))) || \
-                          ((b < 0) && (a < (max - b)))); \
+    _Bool r = !( ((b > 0) && (a > (max - b))) ||   \
+                 ((b < 0) && (a < (max - b))) ); \
+    if(SAFE_LIKELY(r)) \
+        *res = a + b; \
+    return r; \
   }
 
 #define SAFE_DEFINE_UNSIGNED_ADD(T, name, max) \
@@ -406,44 +408,48 @@ SAFE_DEFINE_LARGER_OPS(uint64_t, uint64)
 #define SAFE_DEFINE_SIGNED_SUB(T, name, min, max) \
   SAFE_STATIC_INLINE _Bool \
   safe_##name##_sub (T* res, T a, T b) { \
-      *res = (T) (a - b); \
-      return !SAFE_UNLIKELY ((b > 0 && a < min + b) || \
-                             (b < 0 && a > max + b)); \
+      _Bool r = !((b > 0 && a < min + b) || \
+                  (b < 0 && a > max + b)); \
+      if(SAFE_LIKELY(r)) \
+          *res = a - b; \
+      return r; \
   }
 
 #define SAFE_DEFINE_UNSIGNED_SUB(T, name, max) \
   SAFE_STATIC_INLINE _Bool \
   safe_##name##_sub (T* res, T a, T b) { \
-      *res = (T) (a - b); \
+      *res = a - b; \
       return !SAFE_UNLIKELY(b > a); \
   }
 
 #define SAFE_DEFINE_SIGNED_MUL(T, name, min, max) \
   SAFE_STATIC_INLINE _Bool \
   safe_##name##_mul (T* res, T a, T b) { \
-    *res = (T) (a * b); \
+    _Bool r = 1;  \
     if (a > 0) { \
       if (b > 0) { \
         if (a > (max / b)) { \
-          return 0; \
+          r = 0; \
         } \
       } else { \
         if (b < (min / a)) { \
-          return 0; \
+          r = 0; \
         } \
       } \
     } else { \
       if (b > 0) { \
         if (a < (min / b)) { \
-          return 0; \
+          r = 0; \
         } \
       } else { \
         if ( (a != 0) && (b < (max / a))) { \
-          return 0; \
+          r = 0; \
         } \
       } \
     } \
-    return 1; \
+    if(SAFE_LIKELY(r)) \
+        *res = a * b; \
+    return r; \
   }
 
 #define SAFE_DEFINE_UNSIGNED_MUL(T, name, max) \

--- a/safe.h
+++ b/safe.h
@@ -865,7 +865,7 @@ SAFE_DEFINE_UNSIGNED_MOD(uint64_t, uint64, UINT64_MAX)
 #define safe_mul(res, a, b) SAFE_C11_GENERIC_BINARY_OP(mul, res, a, b)
 #define safe_div(res, a, b) SAFE_C11_GENERIC_BINARY_OP(div, res, a, b)
 #define safe_mod(res, a, b) SAFE_C11_GENERIC_BINARY_OP(mod, res, a, b)
-#define safe_neg(res, v)    SAFE_C11_GENERIC_UNARY_OP (mod, res, v)
+#define safe_neg(res, v)    SAFE_C11_GENERIC_UNARY_OP (neg, res, v)
 #endif
 
 #endif /* !defined(SAFE_H) */

--- a/test.c
+++ b/test.c
@@ -36,7 +36,6 @@ test_safe_generic(const MunitParameter params[], void* user_data) {
     munit_assert_true(safe_##name##_add(&result, 1, max - 1)); \
     munit_assert_cmp_##name(result, ==, max); \
     munit_assert_false(safe_##name##_add(&result, max, 1)); \
-    munit_assert_cmp_##name(result, ==, min); \
     return MUNIT_OK; \
   } \
   \
@@ -48,7 +47,6 @@ test_safe_generic(const MunitParameter params[], void* user_data) {
     munit_assert_true(safe_##name##_sub(&result, 1, 1)); \
     munit_assert_cmp_##name(result, ==, 0); \
     munit_assert_false(safe_##name##_sub(&result, min, 1)); \
-    munit_assert_cmp_##name(result, ==, max); \
     munit_assert_true(safe_##name##_sub(&result, max, 1)); \
     munit_assert_cmp_##name(result, ==, max - 1); \
     return MUNIT_OK; \


### PR DESCRIPTION
Invoking signed overflow is UB.
The check should not be done after the fact
or else UB could ensue.